### PR TITLE
Signal SQLite3ConstraintViolation on constraint errors (#27)

### DIFF
--- a/src/SQLite3-Core-Tests/SQLiteBaseConnectionTest.class.st
+++ b/src/SQLite3-Core-Tests/SQLiteBaseConnectionTest.class.st
@@ -416,6 +416,14 @@ SQLiteBaseConnectionTest >> testColumnNamesNoSuchTable [
 	self assert: (columns isNil).
 ]
 
+{ #category : #'tests - connections' }
+SQLiteBaseConnectionTest >> testConstraintViolation [
+	db
+		basicExecute: 'create table x (value integer primary key);';
+		basicExecute: 'insert into x values(1);'.
+	self should: [ db basicExecute: 'insert into x values(1);' ] raise: SQLite3ConstraintViolation 
+]
+
 { #category : #'tests - execution' }
 SQLiteBaseConnectionTest >> testDataValuesAvailable [
 	| s | 

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -348,7 +348,9 @@ SQLite3PreparedStatement >> stepOk: aValue [
 	(aValue = SQLITE_BUSY)
 		ifTrue: [ connection signal: SQLite3Busy with: aValue ].
 	(aValue = SQLITE_MISUSE)
-		ifTrue: [ connection signal: SQLite3Misuse with: aValue ].				
+		ifTrue: [ connection signal: SQLite3Misuse with: aValue ].
+	(aValue = SQLITE_CONSTRAINT)
+		ifTrue:  [ connection signal: SQLite3ConstraintViolation with: aValue].				
 
 	"Catch any error not specifically handled above."
 	connection signal: SQLite3AbstractError with: aValue


### PR DESCRIPTION
* Signal a specialized exception in case of SQLITE_CONSTRAINT error.

* Add test case for SQLite3ConstraintViolation exceptions