### PR TITLE
Rework the way text parameters are bound in a prepared statement, by …

### DIFF
--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -883,7 +883,13 @@ SQLite3Library >> win32ModuleName [
 
 { #category : #operating }
 SQLite3Library >> with: aStatement at: aColumn putBlob: aByteArray [
-	^ self apiBindBlob: aStatement atColumn: aColumn with: aByteArray with: aByteArray size with: -1 
+
+	^ self
+		  apiBindBlob: aStatement
+		  atColumn: aColumn
+		  with: aByteArray
+		  with: aByteArray size
+		  with: 0
 ]
 
 { #category : #operating }

--- a/src/SQLite3-Core/SQLite3Library.class.st
+++ b/src/SQLite3-Core/SQLite3Library.class.st
@@ -186,7 +186,7 @@ SQLite3Library >> apiBindParameterIndex: aStatement for: aName [
 ]
 
 { #category : #'private - api' }
-SQLite3Library >> apiBindString: aStatement atColumn: aColumn with: aString with: anInteger with: anotherInteger [
+SQLite3Library >> apiBindText: aStatement atColumn: aColumn with: aString with: anInteger with: anotherInteger [
 	"int sqlite3_bind_text(sqlite3_stmt*, int, const char*, int, void(*)(void*))"
 	 
 	^ self ffiCall: #(int sqlite3_bind_text (sqlite3_stmt* aStatement, int aColumn, String aString, int anInteger, int anotherInteger))
@@ -897,11 +897,9 @@ SQLite3Library >> with: aStatement at: aColumn putInteger: anInteger [
 ]
 
 { #category : #operating }
-SQLite3Library >> with: aStatement at: aColumn putString: aString [
-	| s |
-	
-	s := self pharoStringToUTF8: aString.
-	^self apiBindString: aStatement atColumn: aColumn with: s with: s size with: -1 
+SQLite3Library >> with: aStatement at: aColumn putText: aByteArray [
+
+	^self apiBindText: aStatement atColumn: aColumn with: aByteArray with: aByteArray size with: 0 
 ]
 
 { #category : #operating }

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -30,7 +30,10 @@ SQLite3PreparedStatement >> at: aColumn putBoolean: aBoolean [
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putByteArray: anObject [
-	^ self library with: handle at: aColumn putBlob: anObject
+
+	| byteArray |
+	byteArray := self bindingAt: anObject ifAbsentPut: [ anObject ].
+	^ self library with: handle at: aColumn putBlob: byteArray
 ]
 
 { #category : #bindings }
@@ -81,7 +84,13 @@ SQLite3PreparedStatement >> at: aColumn putNil: anObject [
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putObject: anObject [
-	^ self library with: handle at: aColumn putBlob: (FLSerializer serializeToByteArray: anObject)
+
+	| blob |
+	blob := self bindingAt: anObject ifAbsentPut: [ FLSerializer serializeToByteArray: anObject ].
+	^ self library
+		  with: handle
+		  at: aColumn
+		  putBlob: blob
 ]
 
 { #category : #bindings }

--- a/src/SQLite3-Core/SQLite3PreparedStatement.class.st
+++ b/src/SQLite3-Core/SQLite3PreparedStatement.class.st
@@ -8,7 +8,8 @@ Class {
 		'connection',
 		'handle',
 		'changes',
-		'columnNames'
+		'columnNames',
+		'bindings'
 	],
 	#pools : [
 		'SQLite3Constants'
@@ -36,18 +37,23 @@ SQLite3PreparedStatement >> at: aColumn putByteArray: anObject [
 SQLite3PreparedStatement >> at: aColumn putDate: aDate [
 
 	| string |
-
-	string := SQLite3DateTimeString
-		streamContents: [ :stream | BasicDatePrinter new printDate: aDate format: #() on: stream ].
-	^ self library with: handle at: aColumn putString: string
+	string := self bindingAt: aDate ifAbsentPut: [ 
+		          SQLite3DateTimeString streamContents: [ :stream | 
+			          BasicDatePrinter new
+				          printDate: aDate
+				          format: #(  )
+				          on: stream ] ].
+	^ self library with: handle at: aColumn putText: string
 ]
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putDateTime: aDateTime [
+
 	| s |
-	
-	s := SQLite3DateTimeString streamContents: [ :stream | aDateTime asDateAndTime printOn: stream ].
-	^ self library with: handle at: aColumn putString: s
+	s := self bindingAt: aDateTime ifAbsentPut: [ 
+		     SQLite3DateTimeString streamContents: [ :stream | 
+			     aDateTime asDateAndTime printOn: stream ] ].
+	^ self library with: handle at: aColumn putText: s
 ]
 
 { #category : #bindings }
@@ -80,16 +86,21 @@ SQLite3PreparedStatement >> at: aColumn putObject: anObject [
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putString: aString [
-	^ self library with: handle at: aColumn putString: aString
+
+	| s |
+	s := self bindingAt: aString
+		     ifAbsentPut: [ self library pharoStringToUTF8: aString ].
+	^ self library with: handle at: aColumn putText: s
 ]
 
 { #category : #bindings }
 SQLite3PreparedStatement >> at: aColumn putTime: aTime [
 
 	| string |
-
-	string := SQLite3DateTimeString streamContents: [ :stream | aTime printOn: stream ].
-	^ self library with: handle at: aColumn putString: string
+	string := self bindingAt: aTime ifAbsentPut: [ 
+		          SQLite3DateTimeString streamContents: [ :stream | 
+			          aTime printOn: stream ] ].
+	^ self library with: handle at: aColumn putText: string
 ]
 
 { #category : #public }
@@ -148,6 +159,11 @@ Parameters that are not assigned values using sqlite3_bind() are treated as NULL
 				ifTrue: [ self perform: (self dataTypeForObject: v) with: idx with: v ] ]
 ]
 
+{ #category : #bindings }
+SQLite3PreparedStatement >> bindingAt: anObject ifAbsentPut: aBlock [
+	^bindings at: anObject ifAbsentPut: aBlock
+]
+
 { #category : #fetching }
 SQLite3PreparedStatement >> booleanAt: aColumn [ 
 	^self library booleanFrom: handle at: aColumn
@@ -182,9 +198,12 @@ SQLite3PreparedStatement >> checkOk: aValue [
 ]
 
 { #category : #bindings }
-SQLite3PreparedStatement >> clearBindings [ 
+SQLite3PreparedStatement >> clearBindings [
 
-	^self library clearBindings: handle on: connection handle
+	| cleared |
+	cleared := self library clearBindings: handle on: connection handle.
+	bindings removeAll.
+	^cleared
 ]
 
 { #category : #public }
@@ -302,6 +321,7 @@ SQLite3PreparedStatement >> handle [
 SQLite3PreparedStatement >> initialize [
 
 	super initialize.
+	bindings := IdentityDictionary new.
 	handle := SQLite3StatementExternalObject new.
 	handle autoRelease
 ]


### PR DESCRIPTION
…asking SQLite to take a copy of the UTF8-encoded string.

We achieve this by passing 0 (SQLITE_STATIC) instead of -1 (SQLITE_TRANSIENT) as the fifth argument to the sqlite3_bind_text() API. To ensure that the bound UTF8-encoded ByteArray passed to SQLite3 has the same lifetime as the statement, keep a cache of these objects in an IdentityDictionary held by the SQLite3PreparedStatement object.